### PR TITLE
chore: add MIT LICENSE and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+﻿# CODEOWNERS for hyperhash-core
+# Teams are placeholders; @caldefenwycke guarantees ownership even if teams don’t exist yet.
+
+*                                   @hyperhash-org/core @caldefenwycke
+/cmd/**                             @hyperhash-org/core @caldefenwycke
+/internal/**                        @hyperhash-org/core @caldefenwycke
+/configs/**                         @hyperhash-org/infra @caldefenwycke
+/scripts/**                         @hyperhash-org/infra @caldefenwycke
+/docs/**                            @hyperhash-org/docs @caldefenwycke

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+﻿MIT License
+
+Copyright (c) 2025 Hyperhash Org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adds MIT LICENSE and CODEOWNERS.

- LICENSE: MIT (c) 2025 Hyperhash Org
- CODEOWNERS: default @hyperhash-org/core @caldefenwycke; infra/docs patterns.

Closes #65